### PR TITLE
feat: ローカル開発環境でcloudflared経由のアクセスを許可

### DIFF
--- a/dev/backend/internal/router/router.go
+++ b/dev/backend/internal/router/router.go
@@ -6,6 +6,7 @@ import (
 	internalMiddleware "backend/internal/middleware"
 	"backend/internal/repository"
 	"backend/internal/usecase"
+	"strings"
 
 	"log/slog"
 
@@ -22,9 +23,18 @@ func InitRoutes(e *echo.Echo, db *gorm.DB, cfg *config.Config, genaiClient *gena
 	e.Use(middleware.RequestID())
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins:     []string{"http://localhost:5173"},
 		AllowCredentials: true,
 		AllowHeaders:     []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
+		AllowOriginFunc: func(origin string) (bool, error) {
+			if origin == "http://localhost:5173" {
+				return true, nil
+			}
+			if strings.HasSuffix(origin, ".trycloudflare.com") {
+				return true, nil
+			}
+
+			return false, nil
+		},
 	}))
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		LogStatus:   true,

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -45,6 +45,14 @@ services:
     networks:
       - chat-branch-net
 
+  tunnel:
+    image: cloudflare/cloudflared:latest
+    container_name: quick_tunnel
+    restart: unless-stopped
+    networks:
+      - chat-branch-net
+    command: tunnel --url http://react-chat-branch:5173
+
 volumes:
   chat-branch-data:
 

--- a/dev/frontend/src/lib/api-client.ts
+++ b/dev/frontend/src/lib/api-client.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export const apiClient = axios.create({
-  baseURL: "http://localhost:1323",
+  baseURL: "",
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",

--- a/dev/frontend/vite.config.ts
+++ b/dev/frontend/vite.config.ts
@@ -21,5 +21,12 @@ export default defineConfig({
   },
   server: {
     host: true,
+    allowedHosts: true,
+    proxy: {
+      "/api": {
+        target: "http://golang-chat-branch:1323",
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
ローカル開発環境でcloudflared経由でのアクセスを許可するように設定しました。
# 主な変更点:
- docker-compose: cloudflaredサービスを追加し、フロントエンドへのトンネリングを設定
- frontend (vite.config.ts): cloudflaredからのアクセスを許可し、バックエンドへのプロキシを設定
- frontend (api-client.ts): viteのプロキシを利用するため、baseURLを削除
- backend (router.go): cloudflaredで生成されるドメインからのCORSアクセスを許可。

# その他:
resolves #48